### PR TITLE
temporarily capturing contact form in formspree

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -237,26 +237,26 @@ landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
 
                     <div class="col-xl-6 col-lg-6 mb-30">
                         <div class="contact-content">
-                            <form action="sendmail.php" method="post" id="contactForm">
+                            <form action="https://formspree.io/f/xdoqevjy" method="post" id="contactForm">
                                 <div class="form-group">
                                     <label for="name">Name:</label>
                                     <input type="text" class="form-control" id="name" name="name"
-                                           placeholder="Enter Name" maxlength="255" required>
+                                        placeholder="Enter Name" maxlength="255" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="email">Email:</label>
                                     <input type="text" class="form-control" id="email" name="email"
-                                           placeholder="Enter Email" maxlength="255" required>
+                                        placeholder="Enter Email" maxlength="255" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="phone">Phone:</label>
                                     <input type="tel" class="form-control" id="phone" name="phone"
-                                           placeholder="Enter Phone Number" maxlength="15" required>
+                                        placeholder="Enter Phone Number" maxlength="15" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="message">Message:</label>
                                     <textarea class="form-control" id="message" name="message" rows="3"
-                                              placeholder="Enter message" maxlength="1000" required></textarea>
+                                        placeholder="Enter message" maxlength="1000" required></textarea>
                                 </div>
                                 <input type="hidden" name="redirectpage" id="" value="2">
                                 <div class="contact-btn">
@@ -446,7 +446,7 @@ landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
 
     </section>
 
-<!-- /*--------------------------------------------------------------
+    <!-- /*--------------------------------------------------------------
    5.map Section
 ---------------------*/ -->
 

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
                             aria-hidden="true">&times;</span></button>
                 </div>
                 <div class="modal-body">
-                    <form action="sendmail.php" method="post">
+                    <form action="https://formspree.io/f/xdoqevjy" method="post">
                         <div class="form-group">
                             <label for="name">Name:</label>
                             <input type="text" class="form-control" id="name" name="name" placeholder="Enter Name"


### PR DESCRIPTION
Temporarily added a third party service to capture the data and send email notification to sales@utkallabs.com (configurable). Once we have our own code ready we can change it back. Just changed the form action to formspree page, everything else is same.
![image](https://github.com/utkallabs/ul_website_2_0/assets/2333154/c98e0d71-bec2-4bc9-92d7-08f8cbae1123)
